### PR TITLE
WIP: Don't close multiplexer when outgoing dial fails

### DIFF
--- a/pkg/forwarding/controller.go
+++ b/pkg/forwarding/controller.go
@@ -629,10 +629,6 @@ func (c *controller) run(ctx context.Context, source, destination Endpoint) {
 			<-forwardingErrors
 		}
 
-		// Nil out endpoints to update our state.
-		source = nil
-		destination = nil
-
 		// Reset the forwarding state, but propagate the error that caused
 		// failure.
 		c.stateLock.Lock()

--- a/pkg/forwarding/endpoint/local/dialer.go
+++ b/pkg/forwarding/endpoint/local/dialer.go
@@ -69,6 +69,7 @@ func (e *dialerEndpoint) Open() (net.Conn, error) {
 func (e *dialerEndpoint) Shutdown() error {
 	// Cancel the dialing context to unblock any dialing operations.
 	e.dialingCancel()
+	e.dialingContext, e.dialingCancel = context.WithCancel(context.Background())
 
 	// Success.
 	return nil


### PR DESCRIPTION
Currently `(*client).Shutdown` closes the underlying multiplexer. This seems wrong since it causes any forwarded dial attempt to destroy the tunnel, including its listener.

Shutdown is documented as:

    // Shutdown shuts down the endpoint. This function must unblock any pending
    // Open call.

Reimplement it to actually cancel pending `Open`s instead of closing the whole multiplexer.

This seems to fix the particular case I was working on, but I don't know if it will break embedded assumptions. At a minimum, it probably needs some locking. Just opening this for further testing, for now.